### PR TITLE
Fix index redirect

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -61,12 +61,16 @@
                 - ssl_certificate_key /etc/nginx/ssl/gandi-wildcard.key
                 - access_log "/var/log/nginx/foobot-exporter.access.log"
                 - error_log "/var/log/nginx/foobot-exporter.error.log"
-                - location /app { alias "{{ webapp_root }}"; try_files $uri $uri/ /index.html; }
                 - location /static { alias "{{ backend_root }}/static";  }
-                - location / { uwsgi_pass unix:///tmp/{{ app_name }}.sock; 
-                               include uwsgi_params; 
-                               uwsgi_read_timeout 300; 
-                  }
+                - location /ws { 
+                      rewrite /ws(.*) $1 break;
+                      uwsgi_pass unix:///tmp/{{ app_name }}.sock; 
+                      include uwsgi_params; 
+                      uwsgi_read_timeout 300; 
+                      uwsgi_param SCRIPT_NAME /ws;
+                      uwsgi_modifier1 30;
+                    }
+                - location / { root "{{ webapp_root }}"; try_files $uri $uri/ /index.html; }
         tags: install, deploy
 
   tasks:

--- a/foobot_exporter/urls.py
+++ b/foobot_exporter/urls.py
@@ -10,7 +10,6 @@ router.register(r'owners', OwnerViewSet, base_name='owner')
 router.register(r'devices', DeviceViewSet, base_name='device')
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
     url(r'^api/', include(router.urls, namespace='api')),
-    url(r'^$', RedirectView.as_view(url='/app/')),
+    url(r'^$', RedirectView.as_view(url='/')),
 ]


### PR DESCRIPTION
Close #7

The issue was deeper than I though. The brower was trying to access
/index.html which was handled by Django. Unfortunately it could not
be properly redirected to /app/ which is handled by ng2.

Also, ng2 routes where broken (a /about direct access would not work
anymore). The only way out was to place:
* the webapp at /
* django at /ws with a nginx rewrite to remove /ws from the requests